### PR TITLE
Handle extra closing segments

### DIFF
--- a/ocpsvg/ocp.py
+++ b/ocpsvg/ocp.py
@@ -113,7 +113,7 @@ def face_outer_wire(face: TopoDS_Face) -> TopoDS_Wire:
 def face_inner_wires(face: TopoDS_Face) -> list[TopoDS_Wire]:
     """Find the inner wires of a face."""
     outer = face_outer_wire(face)
-    return [cast(TopoDS_Wire, w) for w in topoDS_iterator(face) if not w.IsSame(outer)]
+    return [TopoDS.Wire_s(w) for w in topoDS_iterator(face) if not w.IsSame(outer)]
 
 
 def face_from_wires(

--- a/ocpsvg/svg.py
+++ b/ocpsvg/svg.py
@@ -243,17 +243,17 @@ class ColorAndLabel:
     @property
     def color(self):
         """Fill color if any, stroke color otherwise.
-        For backwards compatibility, use `color_for(shape) instead."""
+        For backwards compatibility, use `color_for(shape)` instead."""
         return self.fill_color if self.fill_color else self.stroke_color
 
     @staticmethod
     def _color(
         color: Union[svgelements.Color, None]
     ) -> Union[tuple[float, float, float, float], None]:
-        if color and color.value:
+        if color and color.value:  # type: ignore
             try:
-                rgba255 = color.red, color.green, color.blue, color.alpha  # type: ignore
-                return tuple(float(v) / 255 for v in rgba255)  # type: ignore
+                rgba = color.red, color.green, color.blue, color.alpha  # type: ignore
+                return tuple(float(v) / 255 for v in rgba)  # type: ignore
             except TypeError:
                 return 0, 0, 0, 1
 


### PR DESCRIPTION
`svgpathtools` will sometime add short line segments to close paths. This seems to mostly happen with relative paths (I assume through error accumulation). In this PR:
- we try and avoid the situation internally by using absolute path strings when converting from `svgpathelements` to `svgpathtools` paths
- we check for these extra closing segments when generating edges