### PR TITLE
use `BRepTools_WireExplorer` to output wires

### DIFF
--- a/ocpsvg/ocp.py
+++ b/ocpsvg/ocp.py
@@ -10,7 +10,7 @@ from OCP.BRepBndLib import BRepBndLib
 from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeFace
 from OCP.BRepFeat import BRepFeat
 from OCP.BRepLib import BRepLib_FindSurface
-from OCP.BRepTools import BRepTools
+from OCP.BRepTools import BRepTools, BRepTools_WireExplorer
 from OCP.Convert import Convert_ParameterisationType
 from OCP.GC import (
     GC_MakeArcOfCircle,
@@ -98,6 +98,7 @@ def bounding_box(
 def topoDS_iterator(
     shape: TopoDS_Shape, with_orientation: bool = True, with_location: bool = True
 ) -> Iterator[TopoDS_Shape]:
+    """Iterate sub shapes with `TopoDS_Iterator`."""
     iterator = TopoDS_Iterator(shape, with_orientation, with_location)
     while iterator.More():
         yield iterator.Value()
@@ -254,6 +255,14 @@ def closed_wire(wire: TopoDS_Wire) -> TopoDS_Wire:
         wire = extend.WireAPIMake()
 
     return wire
+
+
+def wire_explorer(wire: TopoDS_Wire) -> Iterator[TopoDS_Edge]:
+    """Iterate edges with `BRepTools_WireExplorer`."""
+    explorer = BRepTools_WireExplorer(wire)
+    while explorer.More():
+        yield explorer.Current()
+        explorer.Next()
 
 
 #### edges

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "readme-pypi.md"
 version = "0.3.3"
 requires-python = ">=3.9"
 dependencies = [
-    "cadquery-ocp >= 7.7.0",
+    "cadquery-ocp >= 7.7.0, <7.8",
     "svgelements >= 1.9.1, <2",
 ]
 

--- a/tests/ocp.py
+++ b/tests/ocp.py
@@ -1,9 +1,13 @@
+from typing import Iterable
+
+from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeWire
 from OCP.BRepCheck import BRepCheck_Analyzer
 from OCP.BRepGProp import BRepGProp, BRepGProp_Face
 from OCP.BRepTools import BRepTools
 from OCP.gp import gp_Pnt, gp_Vec
 from OCP.GProp import GProp_GProps
-from OCP.TopoDS import TopoDS_Face, TopoDS_Shape
+from OCP.TopoDS import TopoDS_Edge, TopoDS_Face, TopoDS_Shape, TopoDS_Wire
+from OCP.TopTools import TopTools_ListOfShape
 
 
 def face_area(face: TopoDS_Face):
@@ -28,3 +32,14 @@ def is_valid(shape: TopoDS_Shape):
     check = BRepCheck_Analyzer(shape)
     check.SetParallel(True)
     return check.IsValid()
+
+def wire_via_BRepBuilderAPI(edges: Iterable[TopoDS_Edge]) -> TopoDS_Wire:
+    """Make a wire using `BRepBuilderAPI_MakeWire.Wire`"""
+    makewire = BRepBuilderAPI_MakeWire()
+    edge_list = TopTools_ListOfShape()
+    for edge in edges:
+        edge_list.Append(edge)
+    makewire.Add(edge_list)
+    makewire.Build()  # type: ignore
+    return makewire.Wire()
+

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -286,14 +286,14 @@ def test_arc_to_cubic_transformed():
         ),
         (
             extend_curve(ellipse_curve(8, 5, 90, 180, center=gp_Pnt(2, 4, 0)), 2, 3),
-            "M-6,4 L-6,2 A8,5,0,0,1,-6,4 L2,9",
+            "M5,9 L2,9 A8,5,0,0,1,-6,4 L-6,2",
             {},
         ),
         (
             extend_curve(
                 ellipse_curve(8, 5, 90, 180, center=gp_Pnt(2, 4, 0)), 2, 3
             ).Reversed(),
-            "M2,9 L5,9 A8,5,0,0,0,2,9 L-6,4",
+            "M-6,2 L-6,4 A8,5,0,0,0,2,9 L5,9",
             {},
         ),
     ],


### PR DESCRIPTION
Edge storage order in Wires isn't necessarily consistent with the geometry of the curves, Wires may even be degenerate in interesting ways (eg. non-manifold).