### PR TITLE
bump to v0.6.0, depend on cadquery-ocp-proxy 7.9.x, streamline workflows, enhance pyproject.toml, improve compat with OCP 7.9.x

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -8,26 +8,19 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest coverage
-          pip install .
-      - name: Lint with ruff
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py310 .
-          # default set of ruff rules with GitHub Annotations
-          ruff check --output-format=github --target-version=py310 .
-      - name: Test with pytest
+          pip install .[dev]
+      - name: Codecov with pytest
         run: |
           coverage run -m pytest
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+name: lint
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Lint with ruff
+        run: |
+          ruff check --output-format=github .

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -14,16 +14,15 @@ jobs:
           - "3.12"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy
-          pip install .
+          pip install .[dev]
       - name: Typecheck with mypy
         run: |
           mypy --ignore-missing-imports ocpsvg

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,27 +14,21 @@ jobs:
           - "3.12"
         os: 
           - macos-latest
+          - macos-15-intel
           - ubuntu-latest
           - windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest
-          pip install .
-      - name: Lint with ruff
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py310 .
-          # default set of ruff rules with GitHub Annotations
-          ruff check --output-format=github --target-version=py310 .
+          pip install .[dev]
       - name: Test with pytest
         run: |
           pytest

--- a/ocpsvg/hlr.py
+++ b/ocpsvg/hlr.py
@@ -143,8 +143,8 @@ class HiddenLineRenderer:
                     yield HlrEdge(
                         type=type,
                         is_hidden=not is_visible,
-                        projected_edge=TopoDS.Edge_s(edge_in_2d),
-                        edge_in_3d=TopoDS.Edge_s(edge_in_3d),
+                        projected_edge=TopoDS.Edge(edge_in_2d),
+                        edge_in_3d=TopoDS.Edge(edge_in_3d),
                         shape_index=shape_index,
                     )
 

--- a/ocpsvg/ocp.py
+++ b/ocpsvg/ocp.py
@@ -121,7 +121,7 @@ def face_outer_wire(face: TopoDS_Face) -> TopoDS_Wire:
 def face_inner_wires(face: TopoDS_Face) -> list[TopoDS_Wire]:
     """Find the inner wires of a face."""
     outer = face_outer_wire(face)
-    return [TopoDS.Wire_s(w) for w in topoDS_iterator(face) if not w.IsSame(outer)]
+    return [TopoDS.Wire(w) for w in topoDS_iterator(face) if not w.IsSame(outer)]
 
 
 def face_from_wires(
@@ -252,10 +252,10 @@ def closed_wire(wire: TopoDS_Wire) -> TopoDS_Wire:
         # wire has no edges
         return wire
 
-    adaptor = BRepAdaptor_Curve(TopoDS.Edge_s(first_edge))
+    adaptor = BRepAdaptor_Curve(TopoDS.Edge(first_edge))
     start = adaptor.Value(adaptor.FirstParameter())
 
-    adaptor = BRepAdaptor_Curve(TopoDS.Edge_s(last_edge))
+    adaptor = BRepAdaptor_Curve(TopoDS.Edge(last_edge))
     end = adaptor.Value(adaptor.LastParameter())
 
     if not start.IsEqual(end, _TOLERANCE):

--- a/ocpsvg/svg.py
+++ b/ocpsvg/svg.py
@@ -204,9 +204,9 @@ def import_svg_document(
             if flip_y:
                 mirrored.Reverse()
             if isinstance(shape, TopoDS_Face):
-                return TopoDS.Face_s(mirrored)
+                return TopoDS.Face(mirrored)
             elif isinstance(shape, TopoDS_Wire):
-                return TopoDS.Wire_s(mirrored)
+                return TopoDS.Wire(mirrored)
             else:
                 raise AssertionError(f"somehow got unexpected shape {shape}")
 
@@ -344,7 +344,7 @@ def wires_from_svg_element(element: ShapeElement) -> Iterator[TopoDS_Wire]:
                 *(element.transform.b, element.transform.d, 0.0, element.transform.f),  # type: ignore
                 *(0.0, 0.0, 1.0, 0.0),  # type: ignore
             )
-            return TopoDS.Wire_s(BRepBuilderAPI_Transform(wire, trsf).Shape())
+            return TopoDS.Wire(BRepBuilderAPI_Transform(wire, trsf).Shape())
         else:
             gtrsf = gp_GTrsf()
             gtrsf.SetValue(1, 1, element.transform.a)  # type: ignore
@@ -353,7 +353,7 @@ def wires_from_svg_element(element: ShapeElement) -> Iterator[TopoDS_Wire]:
             gtrsf.SetValue(2, 2, element.transform.d)  # type: ignore
             gtrsf.SetValue(1, 4, element.transform.e)  # type: ignore
             gtrsf.SetValue(1, 4, element.transform.f)  # type: ignore
-            return TopoDS.Wire_s(BRepBuilderAPI_GTransform(wire, gtrsf).Shape())
+            return TopoDS.Wire(BRepBuilderAPI_GTransform(wire, gtrsf).Shape())
 
     if isinstance(element, (svgelements.Circle, svgelements.Ellipse)):
         cx = float(element.cx)  # type: ignore
@@ -498,7 +498,7 @@ def face_to_svg_path(
     for wire in topoDS_iterator(face):
         cmd = None
         for cmd in wire_to_svg_path(
-            TopoDS.Wire_s(wire),
+            TopoDS.Wire(wire),
             tolerance=tolerance,
             use_cubics=use_cubics,
             use_quadratics=use_quadratics,
@@ -527,7 +527,7 @@ def wire_to_svg_path(
 
     yield from chain.from_iterable(
         edge_to_svg_path(
-            TopoDS.Edge_s(edge),
+            TopoDS.Edge(edge),
             tolerance=tolerance,
             use_cubics=use_cubics,
             use_quadratics=use_quadratics,
@@ -543,7 +543,7 @@ def wire_to_svg_path(
     # We'll add remaining edges individually
 
     # TODO use a set if/when OCP implements `__eq__`
-    all_edges = {hash(e): e for e in map(TopoDS.Edge_s, topoDS_iterator(wire))}
+    all_edges = {hash(e): e for e in map(TopoDS.Edge, topoDS_iterator(wire))}
 
     if len(ordered_edges) < len(all_edges):
         for e in ordered_edges:
@@ -551,7 +551,7 @@ def wire_to_svg_path(
 
         yield from chain.from_iterable(
             edge_to_svg_path(
-                TopoDS.Edge_s(edge),
+                TopoDS.Edge(edge),
                 tolerance=tolerance,
                 use_cubics=use_cubics,
                 use_quadratics=use_quadratics,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,33 @@ readme = "readme-pypi.md"
 version = "0.6.0"
 requires-python = ">=3.10"
 dependencies = [
-    "cadquery-ocp-proxy >= 7.9, < 8.0",
+    "cadquery_ocp_proxy >= 7.9, < 8.0",
     "svgelements >= 1.9.1, <2",
 ]
 
 
 [project.optional-dependencies]
 dev = [
+    "cadquery_ocp_novtk >=7.9, < 8.0",
     "pytest",
+    "coverage",
+    "mypy",
+    "ruff",
 ]
 
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 [project]
 name = "ocpsvg"
 readme = "readme-pypi.md"
-version = "0.5.0"
+version = "0.6.0"
 requires-python = ">=3.10"
 dependencies = [
-    "cadquery-ocp >= 7.8.1, < 7.9.0",
+    "cadquery-ocp-proxy >= 7.9, < 8.0",
     "svgelements >= 1.9.1, <2",
 ]
 

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -207,7 +207,7 @@ def test_arc_to_cubic_transformed():
 
     t = gp_Trsf()
     t.SetTranslationPart(gp_Vec(8, 4, 0))
-    transformed_edge = TopoDS.Edge_s(
+    transformed_edge = TopoDS.Edge(
         BRepBuilderAPI_Transform(edge, t, False, False).Shape()
     )
 
@@ -319,7 +319,7 @@ def test_nonmanifold_wire():
     ],
 )
 def test_wire_to_svg(wire: TopoDS_Wire, svg_d: str, opts: dict[str, Any]):
-    path = SvgPath(wire_to_svg_path(TopoDS.Wire_s(wire), tolerance=1e-5, **opts))
+    path = SvgPath(wire_to_svg_path(TopoDS.Wire(wire), tolerance=1e-5, **opts))
     assert svg_path_tokens(path) == approx(svg_path_tokens(svg_d), abs=1e-4), str(path)
 
 
@@ -982,7 +982,7 @@ def test_fix_closing_lines_str():
     )
     for wire in wires_from_svg_path(d):
         for edge in topoDS_iterator(wire):
-            curve = edge_to_curve(TopoDS.Edge_s(edge))
+            curve = edge_to_curve(TopoDS.Edge(edge))
             assert curve.GetType() != GeomAbs_CurveType.GeomAbs_Line
 
 
@@ -1027,7 +1027,7 @@ def test_circles_and_ellipses(
     assert isinstance(imported[0], TopoDS_Wire)
 
     curves = [
-        edge_to_curve(TopoDS.Edge_s(e)).Curve().Curve()
+        edge_to_curve(TopoDS.Edge(e)).Curve().Curve()
         for e in topoDS_iterator(imported[0])
     ]
     assert len(curves) == 1


### PR DESCRIPTION
This is per our discussions on discord. In summary, ocpsvg needs to depend on the proxy package. I updated the package name and the version range as well as a bump to the version of this package to v0.6.0 (which is outside of the version range allowed by build123d -- that will be changed once ocp 7.9 is enabled by build123d).